### PR TITLE
黑客松#1顺延两周并统一时间门禁

### DIFF
--- a/.github/workflows/process-preregistration.yml
+++ b/.github/workflows/process-preregistration.yml
@@ -10,9 +10,31 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+    env:
+      HACKATHON_TZ: Asia/Shanghai
+      PREREGISTRATION_CLOSES_AT: '2026-04-20 00:00:00'
 
     steps:
+      - name: Validate pre-registration window
+        id: validate-window
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          NOW=$(TZ="$HACKATHON_TZ" date +%s)
+          CLOSES_AT=$(TZ="$HACKATHON_TZ" date -d "$PREREGISTRATION_CLOSES_AT" +%s)
+
+          if [ "$NOW" -ge "$CLOSES_AT" ]; then
+            gh issue comment "$ISSUE_NUMBER" --repo "${{ github.repository }}" --body "**Pre-registration is closed.** Hackathon #1 now runs April 20 - May 3, 2026 (Asia/Shanghai), so team formation closed when the event began."
+            gh issue close "$ISSUE_NUMBER" --repo "${{ github.repository }}" --reason not_planned
+            echo "window_open=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "window_open=true" >> "$GITHUB_OUTPUT"
+
       - name: Post to tracking issue and close
+        if: steps.validate-window.outputs.window_open == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_BODY: ${{ github.event.issue.body }}

--- a/.github/workflows/process-submission.yml
+++ b/.github/workflows/process-submission.yml
@@ -11,12 +11,44 @@ jobs:
     permissions:
       contents: write
       issues: write
+    env:
+      HACKATHON_TZ: Asia/Shanghai
+      SUBMISSION_START_AT: '2026-04-20 00:00:00'
+      SUBMISSION_END_AT: '2026-05-04 00:00:00'
 
     steps:
+      - name: Validate submission window
+        id: validate-window
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          NOW=$(TZ="$HACKATHON_TZ" date +%s)
+          START=$(TZ="$HACKATHON_TZ" date -d "$SUBMISSION_START_AT" +%s)
+          END=$(TZ="$HACKATHON_TZ" date -d "$SUBMISSION_END_AT" +%s)
+
+          if [ "$NOW" -lt "$START" ]; then
+            gh issue comment "$ISSUE_NUMBER" --repo "${{ github.repository }}" --body "**Submissions are not open yet.** Hackathon #1 project submissions open on April 20, 2026 (Asia/Shanghai). Please resubmit once the event begins."
+            gh issue close "$ISSUE_NUMBER" --repo "${{ github.repository }}" --reason not_planned
+            echo "window_open=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$NOW" -ge "$END" ]; then
+            gh issue comment "$ISSUE_NUMBER" --repo "${{ github.repository }}" --body "**Submissions are closed.** Hackathon #1 accepted project submissions through May 3, 2026 (Asia/Shanghai)."
+            gh issue close "$ISSUE_NUMBER" --repo "${{ github.repository }}" --reason not_planned
+            echo "window_open=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "window_open=true" >> "$GITHUB_OUTPUT"
+
       - name: Checkout repository
+        if: steps.validate-window.outputs.window_open == 'true'
         uses: actions/checkout@v4
 
       - name: Parse issue and save submission
+        if: steps.validate-window.outputs.window_open == 'true'
         env:
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_BODY: ${{ github.event.issue.body }}
@@ -80,6 +112,7 @@ jobs:
           cat "$DATA_FILE"
 
       - name: Commit and push
+        if: steps.validate-window.outputs.window_open == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -88,6 +121,7 @@ jobs:
           git push
 
       - name: Label and close issue
+        if: steps.validate-window.outputs.window_open == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ A multi-format hackathon program by [DSL (Data Intelligence for Scientific Innov
 
 ## Current Edition
 
-**DSL Hackathon #1 (April 2026)**
+**DSL Hackathon #1 (Apr-May 2026)**
 
-- **Date:** April 06 — 19, 2026
+- **Date:** April 20 — May 03, 2026
 - **Location:** DSL 511
 - **Theme:** Enhancing Research Efficiency with Generative AI
 - **Participants:** DSL Members
@@ -60,4 +60,3 @@ group-hackathon-series/
 - [SciHorizon](https://www.scihorizon.cn/)
 - [SciMatrix](https://www.scimatrix.cn/)
 - [NanoAgent Team](https://nanoagentteam.github.io/)
-

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -3,6 +3,14 @@
    ======================================== */
 
 document.addEventListener('DOMContentLoaded', () => {
+  const hackathonSchedule = {
+    startsAt: new Date('2026-04-20T00:00:00+08:00'),
+    preRegistrationClosesAt: new Date('2026-04-20T00:00:00+08:00'),
+    submissionsCloseAt: new Date('2026-05-04T00:00:00+08:00'),
+    startsLabel: 'April 20, 2026',
+    endsLabel: 'May 3, 2026',
+    windowLabel: 'April 20 — May 3, 2026',
+  };
 
   // ---------- Pixel Cursor + Ring Follower + Trail ----------
   const pixelCursor = document.getElementById('cursorPixel');
@@ -430,14 +438,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
     submitBtn.addEventListener('click', () => {
       const now = new Date();
-      const start = new Date('2026-04-06T00:00:00');
-      const end = new Date('2026-04-20T00:00:00');
-      if (now < start) {
-        showToast('Submission is not open yet — starts April 6, 2026', true);
+      if (now < hackathonSchedule.startsAt) {
+        showToast(`Submission is not open yet — starts ${hackathonSchedule.startsLabel}`, true);
         return;
       }
-      if (now >= end) {
-        showToast('Submission has ended — closed after April 19, 2026', true);
+      if (now >= hackathonSchedule.submissionsCloseAt) {
+        showToast(`Submission has ended — closed after ${hackathonSchedule.endsLabel}`, true);
         return;
       }
       openModal();
@@ -523,9 +529,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     preRegBtn.addEventListener('click', () => {
       const now = new Date();
-      const start = new Date('2026-04-06T00:00:00');
-      if (now >= start) {
-        showToast('Pre-registration has closed — the hackathon has begun!', true);
+      if (now >= hackathonSchedule.preRegistrationClosesAt) {
+        showToast(`Pre-registration has closed — Hackathon #1 now runs ${hackathonSchedule.windowLabel}.`, true);
         return;
       }
       openPreReg();

--- a/editions/1.html
+++ b/editions/1.html
@@ -147,7 +147,7 @@
           DSL Hackathon <span class="text-gold">#1</span>
         </h1>
         <p class="edition-detail__subtitle reveal-up" style="--delay: 0.3s">
-          April 2026 · Enhancing Research Efficiency with Generative AI
+          Apr-May 2026 · Enhancing Research Efficiency with Generative AI
         </p>
       </div>
     </section>
@@ -199,7 +199,7 @@
         <div class="edition-detail__info-grid reveal-up" style="--delay: 0.2s">
           <div class="edition-detail__info-card">
             <span class="edition-detail__info-label">Date</span>
-            <span class="edition-detail__info-value">April 06 — 19, 2026</span>
+            <span class="edition-detail__info-value">April 20 — May 03, 2026</span>
           </div>
           <div class="edition-detail__info-card">
             <span class="edition-detail__info-label">Location</span>

--- a/index.html
+++ b/index.html
@@ -209,7 +209,7 @@
         <div class="current__info">
           <span class="section__label reveal-up">Current Edition</span>
           <h2 class="current__title reveal-up" style="--delay: 0.1s">
-            DSL Hackathon <span class="text-gold">#1</span> (April 2026)
+            DSL Hackathon <span class="text-gold">#1</span> (Apr-May 2026)
           </h2>
           <p class="current__desc reveal-up" style="--delay: 0.2s">
             The inaugural DSL Hackathon will be held within the research group, focusing on how to leverage generative AI tools—such as Claude Code, NotebookLM, Nano Banana, OpenClaw, and Agent Skills—to enhance research efficiency and productivity. Participants may join individually or form teams of up to three members.
@@ -217,7 +217,7 @@
           <div class="current__details reveal-up" style="--delay: 0.3s">
             <div class="current__detail">
               <span class="current__detail-label">Date</span>
-              <span class="current__detail-value">April 06 — 19, 2026</span>
+              <span class="current__detail-value">April 20 — May 03, 2026</span>
             </div>
             <div class="current__detail">
               <span class="current__detail-label">Location</span>
@@ -306,11 +306,11 @@
         <a href="editions/1.html" class="edition-card reveal-up" style="--delay: 0.15s" data-year="2026">
           <div class="edition-card__left">
             <span class="edition-card__number">01</span>
-            <h3 class="edition-card__title">DSL Hackathon #1 (April 2026)</h3>
+            <h3 class="edition-card__title">DSL Hackathon #1 (Apr-May 2026)</h3>
             <span class="edition-card__theme">Generative AI for Research</span>
           </div>
           <div class="edition-card__right">
-            <span class="edition-card__date">Apr 2026</span>
+            <span class="edition-card__date">Apr-May 2026</span>
             <div class="edition-card__arrow">
               <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
                 <path d="M7 17L17 7M17 7H7M17 7V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>


### PR DESCRIPTION
## 变更概述
将 Hackathon #1 时间从 2026-04-06 ~ 2026-04-19 顺延两周到 2026-04-20 ~ 2026-05-03，并同步前端展示、前端时间门禁与 GitHub Actions 服务端校验。

## 每个文件的修改思路
- README.md：更新当前届次标题与日期，确保仓库文档与延期安排一致。
- index.html：统一首页 Current 区块和归档卡片中的日期展示，避免不同入口信息不一致。
- editions/1.html：同步详情页副标题与 Date 字段，保持页面间一致性。
- assets/js/main.js：集中定义活动时间常量（Asia/Shanghai），并让预报名/提交逻辑复用同一时间源，降低后续维护成本。
- .github/workflows/process-submission.yml：新增服务端提交时间窗校验，防止绕过前端直接发 issue 的越窗提交。
- .github/workflows/process-preregistration.yml：新增服务端预报名截止校验，使 issue 处理规则与延期后的时间线一致。

## 备注
GitHub 上用于预报名展示的 issue #3 正文仍是旧日期，建议在仓库页面手动更新该 issue 文案。