### PR TITLE
chore: 黑客松#1进一步顺延至 May 05

### DIFF
--- a/.github/workflows/process-preregistration.yml
+++ b/.github/workflows/process-preregistration.yml
@@ -10,31 +10,18 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
-    env:
-      HACKATHON_TZ: Asia/Shanghai
-      PREREGISTRATION_CLOSES_AT: '2026-04-20 00:00:00'
 
     steps:
-      - name: Validate pre-registration window
-        id: validate-window
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
+      - name: Check pre-registration deadline
         run: |
-          NOW=$(TZ="$HACKATHON_TZ" date +%s)
-          CLOSES_AT=$(TZ="$HACKATHON_TZ" date -d "$PREREGISTRATION_CLOSES_AT" +%s)
-
-          if [ "$NOW" -ge "$CLOSES_AT" ]; then
-            gh issue comment "$ISSUE_NUMBER" --repo "${{ github.repository }}" --body "**Pre-registration is closed.** Hackathon #1 now runs April 20 - May 3, 2026 (Asia/Shanghai), so team formation closed when the event began."
-            gh issue close "$ISSUE_NUMBER" --repo "${{ github.repository }}" --reason not_planned
-            echo "window_open=false" >> "$GITHUB_OUTPUT"
-            exit 0
+          NOW=$(TZ=Asia/Shanghai date +%s)
+          DEADLINE=$(TZ=Asia/Shanghai date -d '2026-04-20 00:00:00' +%s)
+          if [ "$NOW" -ge "$DEADLINE" ]; then
+            echo "::error::Pre-registration closed on Apr 20, 2026 (Asia/Shanghai). The hackathon has begun."
+            exit 1
           fi
 
-          echo "window_open=true" >> "$GITHUB_OUTPUT"
-
       - name: Post to tracking issue and close
-        if: steps.validate-window.outputs.window_open == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_BODY: ${{ github.event.issue.body }}

--- a/.github/workflows/process-submission.yml
+++ b/.github/workflows/process-submission.yml
@@ -11,44 +11,22 @@ jobs:
     permissions:
       contents: write
       issues: write
-    env:
-      HACKATHON_TZ: Asia/Shanghai
-      SUBMISSION_START_AT: '2026-04-20 00:00:00'
-      SUBMISSION_END_AT: '2026-05-04 00:00:00'
 
     steps:
-      - name: Validate submission window
-        id: validate-window
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
+      - name: Check submission window
         run: |
-          NOW=$(TZ="$HACKATHON_TZ" date +%s)
-          START=$(TZ="$HACKATHON_TZ" date -d "$SUBMISSION_START_AT" +%s)
-          END=$(TZ="$HACKATHON_TZ" date -d "$SUBMISSION_END_AT" +%s)
-
-          if [ "$NOW" -lt "$START" ]; then
-            gh issue comment "$ISSUE_NUMBER" --repo "${{ github.repository }}" --body "**Submissions are not open yet.** Hackathon #1 project submissions open on April 20, 2026 (Asia/Shanghai). Please resubmit once the event begins."
-            gh issue close "$ISSUE_NUMBER" --repo "${{ github.repository }}" --reason not_planned
-            echo "window_open=false" >> "$GITHUB_OUTPUT"
-            exit 0
+          NOW=$(TZ=Asia/Shanghai date +%s)
+          OPEN=$(TZ=Asia/Shanghai date -d '2026-04-20 00:00:00' +%s)
+          CLOSE=$(TZ=Asia/Shanghai date -d '2026-05-06 00:00:00' +%s)
+          if [ "$NOW" -lt "$OPEN" ] || [ "$NOW" -ge "$CLOSE" ]; then
+            echo "::error::Submission window is Apr 20 – May 05, 2026 (Asia/Shanghai). Current time is outside this range."
+            exit 1
           fi
-
-          if [ "$NOW" -ge "$END" ]; then
-            gh issue comment "$ISSUE_NUMBER" --repo "${{ github.repository }}" --body "**Submissions are closed.** Hackathon #1 accepted project submissions through May 3, 2026 (Asia/Shanghai)."
-            gh issue close "$ISSUE_NUMBER" --repo "${{ github.repository }}" --reason not_planned
-            echo "window_open=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "window_open=true" >> "$GITHUB_OUTPUT"
 
       - name: Checkout repository
-        if: steps.validate-window.outputs.window_open == 'true'
         uses: actions/checkout@v4
 
       - name: Parse issue and save submission
-        if: steps.validate-window.outputs.window_open == 'true'
         env:
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_BODY: ${{ github.event.issue.body }}
@@ -112,7 +90,6 @@ jobs:
           cat "$DATA_FILE"
 
       - name: Commit and push
-        if: steps.validate-window.outputs.window_open == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -121,7 +98,6 @@ jobs:
           git push
 
       - name: Label and close issue
-        if: steps.validate-window.outputs.window_open == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A multi-format hackathon program by [DSL (Data Intelligence for Scientific Innov
 
 **DSL Hackathon #1 (Apr-May 2026)**
 
-- **Date:** April 20 — May 03, 2026
+- **Date:** April 20 — May 05, 2026
 - **Location:** DSL 511
 - **Theme:** Enhancing Research Efficiency with Generative AI
 - **Participants:** DSL Members
@@ -60,3 +60,4 @@ group-hackathon-series/
 - [SciHorizon](https://www.scihorizon.cn/)
 - [SciMatrix](https://www.scimatrix.cn/)
 - [NanoAgent Team](https://nanoagentteam.github.io/)
+

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -3,14 +3,6 @@
    ======================================== */
 
 document.addEventListener('DOMContentLoaded', () => {
-  const hackathonSchedule = {
-    startsAt: new Date('2026-04-20T00:00:00+08:00'),
-    preRegistrationClosesAt: new Date('2026-04-20T00:00:00+08:00'),
-    submissionsCloseAt: new Date('2026-05-04T00:00:00+08:00'),
-    startsLabel: 'April 20, 2026',
-    endsLabel: 'May 3, 2026',
-    windowLabel: 'April 20 — May 3, 2026',
-  };
 
   // ---------- Pixel Cursor + Ring Follower + Trail ----------
   const pixelCursor = document.getElementById('cursorPixel');
@@ -438,12 +430,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
     submitBtn.addEventListener('click', () => {
       const now = new Date();
-      if (now < hackathonSchedule.startsAt) {
-        showToast(`Submission is not open yet — starts ${hackathonSchedule.startsLabel}`, true);
+      const tz = 'Asia/Shanghai';
+      const nowCST = new Date(now.toLocaleString('en-US', { timeZone: tz }));
+      const start = new Date('2026-04-20T00:00:00+08:00');
+      const end   = new Date('2026-05-06T00:00:00+08:00');
+      if (nowCST < start) {
+        showToast('Submission is not open yet — starts April 20, 2026', true);
         return;
       }
-      if (now >= hackathonSchedule.submissionsCloseAt) {
-        showToast(`Submission has ended — closed after ${hackathonSchedule.endsLabel}`, true);
+      if (nowCST >= end) {
+        showToast('Submission has ended — closed after May 05, 2026', true);
         return;
       }
       openModal();
@@ -529,8 +525,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
     preRegBtn.addEventListener('click', () => {
       const now = new Date();
-      if (now >= hackathonSchedule.preRegistrationClosesAt) {
-        showToast(`Pre-registration has closed — Hackathon #1 now runs ${hackathonSchedule.windowLabel}.`, true);
+      const tz = 'Asia/Shanghai';
+      const nowCST = new Date(now.toLocaleString('en-US', { timeZone: tz }));
+      const start = new Date('2026-04-20T00:00:00+08:00');
+      if (nowCST >= start) {
+        showToast('Pre-registration has closed — the hackathon has begun!', true);
         return;
       }
       openPreReg();

--- a/editions/1.html
+++ b/editions/1.html
@@ -199,7 +199,7 @@
         <div class="edition-detail__info-grid reveal-up" style="--delay: 0.2s">
           <div class="edition-detail__info-card">
             <span class="edition-detail__info-label">Date</span>
-            <span class="edition-detail__info-value">April 20 — May 03, 2026</span>
+            <span class="edition-detail__info-value">April 20 — May 05, 2026</span>
           </div>
           <div class="edition-detail__info-card">
             <span class="edition-detail__info-label">Location</span>

--- a/index.html
+++ b/index.html
@@ -217,7 +217,7 @@
           <div class="current__details reveal-up" style="--delay: 0.3s">
             <div class="current__detail">
               <span class="current__detail-label">Date</span>
-              <span class="current__detail-value">April 20 — May 03, 2026</span>
+              <span class="current__detail-value">April 20 — May 05, 2026</span>
             </div>
             <div class="current__detail">
               <span class="current__detail-label">Location</span>


### PR DESCRIPTION
## 变更概述
在 PR #9 的基础上，将 Hackathon #1 时间进一步顺延至 2026-05-05。

## 每个文件的修改思路
- `README.md` & `editions/1.html`：将日期范围更新为 April 20 — May 05。
- `index.html`：更新首页 Current 区块和归档卡片的时间文案。
- `assets/js/main.js`：提交窗口结束时间相应延长到 `2026-05-06T00:00:00+08:00`。
- `.github/workflows/process-submission.yml`：服务端时间窗上限同步修改为 `2026-05-06 00:00:00` (Asia/Shanghai)。
