### PR TITLE
fix: trigger Pages deployment after bot commits

### DIFF
--- a/.github/workflows/enrich-submissions.yml
+++ b/.github/workflows/enrich-submissions.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
 
     steps:
       - name: Checkout repository
@@ -77,10 +78,19 @@ jobs:
           echo "Enrichment complete"
 
       - name: Commit and push if changed
+        id: commit
         run: |
-          git diff --quiet data/ && echo "No changes to commit" && exit 0
+          git diff --quiet data/ && echo "No changes to commit" && echo "changed=false" >> "$GITHUB_OUTPUT" && exit 0
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add data/
           git commit -m "Enrich submission data with GitHub API metadata"
           git push
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger Pages deployment
+        if: steps.commit.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run "Deploy Jekyll with GitHub Pages dependencies preinstalled" --repo ${{ github.repository }}

--- a/.github/workflows/process-submission.yml
+++ b/.github/workflows/process-submission.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: write
       issues: write
+      actions: write
 
     steps:
       - name: Check submission window
@@ -105,3 +106,9 @@ jobs:
           gh issue edit ${{ github.event.issue.number }} --add-label "submission"
           gh issue comment ${{ github.event.issue.number }} --body "✅ **Submission received!** Your project has been recorded successfully. Thank you for participating in the DSL Hackathon!"
           gh issue close ${{ github.event.issue.number }} --reason completed
+
+      - name: Trigger Pages deployment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run "Deploy Jekyll with GitHub Pages dependencies preinstalled" --repo ${{ github.repository }}


### PR DESCRIPTION
## Bug
笑寒已经提交项目，但是网页端看不到提交记录。原因是提交后没有自动触发网页的重新部署。

## Summary
- GitHub Actions 通过 `GITHUB_TOKEN` push 的 commit 不会触发其他 workflow（GitHub 安全限制），导致 `process-submission` 写入数据后 Pages 不会重新部署，网站显示空数据
- 在 `process-submission.yml` 和 `enrich-submissions.yml` 末尾添加 `workflow_dispatch` 步骤，显式触发 Pages 部署
- 添加 `actions: write` 权限以允许触发其他 workflow

## Test plan
- [x] YAML 语法验证通过
- [x] Workflow 结构验证（permissions、steps 顺序）
- [ ] 合并后手动触发一次 Pages 部署验证线上数据显示正常
- [ ] 后续新 submission issue 触发时验证自动部署生效

🤖 Generated with [Claude Code](https://claude.com/claude-code)